### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/octoprint_octoflat/__init__.py
+++ b/octoprint_octoflat/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 # (Don't forget to remove me)
 # This is a basic skeleton for your plugin's __init__.py. You probably want to adjust the class name of your plugin
@@ -50,7 +50,7 @@ class OctoflatPlugin(octoprint.plugin.AssetPlugin):
 # ("OctoPrint-PluginSkeleton"), you may define that here. Same goes for the other metadata derived from setup.py that
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "OctoFlat Theme"
-__plugin_pythoncompat = ">=2.7, <4"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
     global __plugin_implementation__


### PR DESCRIPTION
Fixes #1 
Add `unicode_literals` to `__future__` imports, and fix compatibility flag. Fully tested.